### PR TITLE
Update init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -2,23 +2,23 @@
 
 set -e
 
-if [ -z "$DB_HOST_NAME"]; then
+if [ -z "$DB_HOST_NAME" ]; then
 	export DB_HOST_NAME=$DB_PORT_3306_TCP_ADDR
 fi
 
-if [ -z "$DB_TCP_PORT"]; then
+if [ -z "$DB_TCP_PORT" ]; then
 	export DB_TCP_PORT=$DB_PORT_3306_TCP_PORT
 fi
 
-if [ -z "$DB_USER_NAME"]; then
+if [ -z "$DB_USER_NAME" ]; then
 	export DB_USER_NAME=$DB_ENV_MYSQL_USER
 fi
 
-if [ -z "$DB_PASSWORD"]; then
+if [ -z "$DB_PASSWORD" ]; then
 	export DB_PASSWORD=$DB_ENV_MYSQL_PASSWORD
 fi
 
-if [ -z "$DATABASE_NAME"]; then
+if [ -z "$DATABASE_NAME" ]; then
 	export DATABASE_NAME=$DB_ENV_MYSQL_DATABASE
 fi
 


### PR DESCRIPTION
the missing space before the closing ] throws a syntax error in the logging. The script completes ok, but can make error diagnosing problematic, if the user is unaware of the issue.
